### PR TITLE
Fix #7 Buffer Callback Conflict

### DIFF
--- a/nfqueue.js
+++ b/nfqueue.js
@@ -66,7 +66,11 @@ NFQueue.prototype.run = function(callback) {
 exports.NFQueue = NFQueue;
 
 exports.createQueueHandler = function(num, buf, callback) {
-  if (!buf) { buf = 65535; }
+  if (typeof callback === 'undefined' && typeof buf === 'function') {
+    callback = buf;
+    buf = 65535;
+  };
+  
   var nfq = new NFQueue();
 
   nfq.open(num, buf);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "iptables"
   ],
   "dependencies": {
-    "nan": "^2.2.0"
+    "nan": "^2.10.0"
   }
 }


### PR DESCRIPTION
Properly assigns buf and callback if only one is provided.
Tested locally, successfully.

No automated testing is included.